### PR TITLE
Allow MSI-X placeholder generation

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -90,6 +90,7 @@ class BuildConfiguration:
     output_dir: Path
     enable_profiling: bool = True
     preload_msix: bool = True
+    allow_msix_placeholder: bool = False
     profile_duration: int = DEFAULT_PROFILE_DURATION
     parallel_writes: bool = True
     max_workers: int = MAX_PARALLEL_FILE_WRITES
@@ -660,6 +661,7 @@ class ConfigurationManager:
             output_dir=Path(args.output).resolve(),
             enable_profiling=args.profile > 0,
             preload_msix=getattr(args, "preload_msix", True),
+            allow_msix_placeholder=getattr(args, "allow_msix_placeholder", False),
             profile_duration=args.profile,
             output_template=getattr(args, "output_template", None),
             donor_template=getattr(args, "donor_template", None),
@@ -969,6 +971,7 @@ class FirmwareBuilder:
                 template_dir=None,
                 output_dir=self.config.output_dir,
                 enable_behavior_profiling=self.config.enable_profiling,
+                allow_msix_placeholder=self.config.allow_msix_placeholder,
             )
         )
 
@@ -1287,6 +1290,11 @@ Examples:
         dest="preload_msix",
         default=True,
         help="Disable preloading of MSI-X data before VFIO binding",
+    )
+    parser.add_argument(
+        "--allow-msix-placeholder",
+        action="store_true",
+        help="Allow generation of placeholder MSI-X table data when hardware reads fail",
     )
     parser.add_argument(
         "--output-template",

--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -166,6 +166,11 @@ def build_sub(parser: argparse._SubParsersAction):
         action="store_true",
         help="Enable legacy compatibility mode (temporarily restores old fallback behavior)",
     )
+    fallback_group.add_argument(
+        "--allow-msix-placeholder",
+        action="store_true",
+        help="Generate placeholder MSI-X table data when hardware reading fails",
+    )
 
 
 def flash_sub(parser: argparse._SubParsersAction):
@@ -304,6 +309,7 @@ def main(argv: Optional[List[str]] = None):
             active_priority=getattr(args, "active_priority", 15),
             output_template=getattr(args, "output_template", None),
             donor_template=getattr(args, "donor_template", None),
+            allow_msix_placeholder=getattr(args, "allow_msix_placeholder", False),
         )
         run_build(cfg)
 

--- a/src/cli/container.py
+++ b/src/cli/container.py
@@ -79,6 +79,7 @@ class BuildConfig:
     fallback_mode: str = "none"  # "none", "prompt", or "auto"
     allowed_fallbacks: List[str] = field(default_factory=list)
     denied_fallbacks: List[str] = field(default_factory=list)
+    allow_msix_placeholder: bool = False
     # active device configuration
     disable_active_device: bool = False
     active_timer_period: int = 100000
@@ -109,6 +110,8 @@ class BuildConfig:
             args.append(f"--output-template {self.output_template}")
         if self.donor_template:
             args.append(f"--donor-template {self.donor_template}")
+        if self.allow_msix_placeholder:
+            args.append("--allow-msix-placeholder")
 
         return args
 

--- a/src/device_clone/pcileech_generator.py
+++ b/src/device_clone/pcileech_generator.py
@@ -81,6 +81,9 @@ class PCILeechGenerationConfig:
     # Donor template
     donor_template: Optional[Dict[str, Any]] = None
 
+    # MSI-X handling
+    allow_msix_placeholder: bool = False
+
 
 class PCILeechGenerator:
     """
@@ -264,6 +267,8 @@ class PCILeechGenerator:
                     interrupt_strategy,
                     interrupt_vectors,
                 )
+                if self.config.allow_msix_placeholder:
+                    template_context["allow_msix_placeholder"] = True
 
             # VFIO cleanup happens here automatically when exiting the 'with' block
             log_info_safe(

--- a/src/templating/sv_module_generator.py
+++ b/src/templating/sv_module_generator.py
@@ -537,6 +537,21 @@ class SVModuleGenerator:
                         0x00000000 | i,  # Message Data
                         0x00000000,  # Vector Control
                     ]
+            )
+            return "\n".join(f"{value:08X}" for value in table_data) + "\n"
+
+        if context.get("allow_msix_placeholder") or context.get(
+            "template_context", {}
+        ).get("allow_msix_placeholder"):
+            table_data = []
+            for i in range(num_vectors):
+                table_data.extend(
+                    [
+                        0xFEE00000 + (i << 4),
+                        0x00000000,
+                        0x00000000 | i,
+                        0x00000000,
+                    ]
                 )
             return "\n".join(f"{value:08X}" for value in table_data) + "\n"
 

--- a/tests/test_systemverilog_generator_advanced.py
+++ b/tests/test_systemverilog_generator_advanced.py
@@ -218,6 +218,18 @@ class TestMSIXAdvancedFunctionality:
                 vector_num = i // 4
                 assert value & 0xFF == vector_num  # Low 8 bits should be vector number
 
+    def test_msix_table_placeholder_generation(self):
+        from src.templating.sv_module_generator import SVModuleGenerator
+        from src.templating.template_renderer import TemplateRenderer
+        import logging
+
+        renderer = TemplateRenderer()
+        gen = SVModuleGenerator(renderer, logging.getLogger(__name__))
+        hex_data = gen._generate_msix_table_init(2, {"allow_msix_placeholder": True})
+        lines = hex_data.strip().split("\n")
+        assert len(lines) == 8
+        assert lines[0] == "FEE00000"
+
     def test_read_msix_table_successful_mapping(
         self, base_generator, standard_msix_context
     ):


### PR DESCRIPTION
## Summary
- add `--allow-msix-placeholder` flag to bypass hardware MSI-X table reads
- allow firmware build pipeline to generate dummy MSI-X table when hardware data is missing
- cover placeholder path with dedicated unit test

## Testing
- `pytest tests/test_systemverilog_generator_advanced.py::TestMSIXAdvancedFunctionality::test_msix_table_placeholder_generation -q --override-ini=addopts=`


------
https://chatgpt.com/codex/tasks/task_b_68b769979670832da861017c5bb76253