### PR TITLE
Expose MSI-X placeholder flag in entrypoint CLI

### DIFF
--- a/pcileech.py
+++ b/pcileech.py
@@ -481,6 +481,11 @@ Environment Variables:
         default=3600,
         help="Timeout for Vivado operations in seconds (default: 3600)",
     )
+    build_parser.add_argument(
+        "--allow-msix-placeholder",
+        action="store_true",
+        help="Use placeholder MSI-X values when hardware MSI-X table reads fail",
+    )
 
     # TUI command
     tui_parser = subparsers.add_parser("tui", help="Launch interactive TUI")
@@ -617,6 +622,8 @@ def handle_build(args):
             cli_args.append("--advanced-sv")
         if args.enable_variance:
             cli_args.append("--enable-variance")
+        if args.allow_msix_placeholder:
+            cli_args.append("--allow-msix-placeholder")
 
         if args.generate_donor_template:
             cli_args.extend(["--output-template", args.generate_donor_template])

--- a/src/build.py
+++ b/src/build.py
@@ -90,6 +90,7 @@ class BuildConfiguration:
     output_dir: Path
     enable_profiling: bool = True
     preload_msix: bool = True
+    allow_msix_placeholder: bool = False
     profile_duration: int = DEFAULT_PROFILE_DURATION
     parallel_writes: bool = True
     max_workers: int = MAX_PARALLEL_FILE_WRITES
@@ -660,6 +661,7 @@ class ConfigurationManager:
             output_dir=Path(args.output).resolve(),
             enable_profiling=args.profile > 0,
             preload_msix=getattr(args, "preload_msix", True),
+            allow_msix_placeholder=getattr(args, "allow_msix_placeholder", False),
             profile_duration=args.profile,
             output_template=getattr(args, "output_template", None),
             donor_template=getattr(args, "donor_template", None),
@@ -969,6 +971,7 @@ class FirmwareBuilder:
                 template_dir=None,
                 output_dir=self.config.output_dir,
                 enable_behavior_profiling=self.config.enable_profiling,
+                allow_msix_placeholder=self.config.allow_msix_placeholder,
             )
         )
 
@@ -1287,6 +1290,11 @@ Examples:
         dest="preload_msix",
         default=True,
         help="Disable preloading of MSI-X data before VFIO binding",
+    )
+    parser.add_argument(
+        "--allow-msix-placeholder",
+        action="store_true",
+        help="Allow generation of placeholder MSI-X table data when hardware reads fail",
     )
     parser.add_argument(
         "--output-template",

--- a/src/cli/cli.py
+++ b/src/cli/cli.py
@@ -166,6 +166,11 @@ def build_sub(parser: argparse._SubParsersAction):
         action="store_true",
         help="Enable legacy compatibility mode (temporarily restores old fallback behavior)",
     )
+    fallback_group.add_argument(
+        "--allow-msix-placeholder",
+        action="store_true",
+        help="Generate placeholder MSI-X table data when hardware reading fails",
+    )
 
 
 def flash_sub(parser: argparse._SubParsersAction):
@@ -304,6 +309,7 @@ def main(argv: Optional[List[str]] = None):
             active_priority=getattr(args, "active_priority", 15),
             output_template=getattr(args, "output_template", None),
             donor_template=getattr(args, "donor_template", None),
+            allow_msix_placeholder=getattr(args, "allow_msix_placeholder", False),
         )
         run_build(cfg)
 

--- a/src/cli/container.py
+++ b/src/cli/container.py
@@ -79,6 +79,7 @@ class BuildConfig:
     fallback_mode: str = "none"  # "none", "prompt", or "auto"
     allowed_fallbacks: List[str] = field(default_factory=list)
     denied_fallbacks: List[str] = field(default_factory=list)
+    allow_msix_placeholder: bool = False
     # active device configuration
     disable_active_device: bool = False
     active_timer_period: int = 100000
@@ -109,6 +110,8 @@ class BuildConfig:
             args.append(f"--output-template {self.output_template}")
         if self.donor_template:
             args.append(f"--donor-template {self.donor_template}")
+        if self.allow_msix_placeholder:
+            args.append("--allow-msix-placeholder")
 
         return args
 

--- a/src/device_clone/pcileech_generator.py
+++ b/src/device_clone/pcileech_generator.py
@@ -81,6 +81,9 @@ class PCILeechGenerationConfig:
     # Donor template
     donor_template: Optional[Dict[str, Any]] = None
 
+    # MSI-X handling
+    allow_msix_placeholder: bool = False
+
 
 class PCILeechGenerator:
     """
@@ -264,6 +267,8 @@ class PCILeechGenerator:
                     interrupt_strategy,
                     interrupt_vectors,
                 )
+                if self.config.allow_msix_placeholder:
+                    template_context["allow_msix_placeholder"] = True
 
             # VFIO cleanup happens here automatically when exiting the 'with' block
             log_info_safe(

--- a/src/templating/sv_module_generator.py
+++ b/src/templating/sv_module_generator.py
@@ -537,6 +537,21 @@ class SVModuleGenerator:
                         0x00000000 | i,  # Message Data
                         0x00000000,  # Vector Control
                     ]
+            )
+            return "\n".join(f"{value:08X}" for value in table_data) + "\n"
+
+        if context.get("allow_msix_placeholder") or context.get(
+            "template_context", {}
+        ).get("allow_msix_placeholder"):
+            table_data = []
+            for i in range(num_vectors):
+                table_data.extend(
+                    [
+                        0xFEE00000 + (i << 4),
+                        0x00000000,
+                        0x00000000 | i,
+                        0x00000000,
+                    ]
                 )
             return "\n".join(f"{value:08X}" for value in table_data) + "\n"
 

--- a/tests/test_pcileech_msix_placeholder_flag.py
+++ b/tests/test_pcileech_msix_placeholder_flag.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Tests for --allow-msix-placeholder flag wiring in pcileech.py."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest  # type: ignore
+
+# Add project root to path for imports
+project_root = Path(__file__).parent.parent
+sys.path.insert(0, str(project_root))
+
+import pcileech
+
+
+class TestMsixPlaceholderFlag:
+    def test_flag_propagated_to_cli(self):
+        with patch("pcileech.get_available_boards", return_value=["mock_board"]), \
+             patch("pcileech.get_logger", return_value=MagicMock()), \
+             patch("pcileech.check_sudo", return_value=True), \
+             patch("pcileech.check_vfio_requirements", return_value=True), \
+             patch("src.cli.cli.main", return_value=0) as mock_cli_main:
+            parser = pcileech.create_parser()
+            args = parser.parse_args([
+                "build",
+                "--bdf",
+                "0000:00:00.0",
+                "--board",
+                "mock_board",
+                "--allow-msix-placeholder",
+            ])
+
+            pcileech.handle_build(args)
+
+            mock_cli_main.assert_called_once_with([
+                "build",
+                "--bdf",
+                "0000:00:00.0",
+                "--board",
+                "mock_board",
+                "--allow-msix-placeholder",
+            ])

--- a/tests/test_systemverilog_generator_advanced.py
+++ b/tests/test_systemverilog_generator_advanced.py
@@ -218,6 +218,18 @@ class TestMSIXAdvancedFunctionality:
                 vector_num = i // 4
                 assert value & 0xFF == vector_num  # Low 8 bits should be vector number
 
+    def test_msix_table_placeholder_generation(self):
+        from src.templating.sv_module_generator import SVModuleGenerator
+        from src.templating.template_renderer import TemplateRenderer
+        import logging
+
+        renderer = TemplateRenderer()
+        gen = SVModuleGenerator(renderer, logging.getLogger(__name__))
+        hex_data = gen._generate_msix_table_init(2, {"allow_msix_placeholder": True})
+        lines = hex_data.strip().split("\n")
+        assert len(lines) == 8
+        assert lines[0] == "FEE00000"
+
     def test_read_msix_table_successful_mapping(
         self, base_generator, standard_msix_context
     ):


### PR DESCRIPTION
## Summary
- add `--allow-msix-placeholder` flag to top-level `pcileech.py` build command
- forward new flag to internal CLI so placeholder MSI-X values can be used when hardware tables aren't accessible
- add unit test ensuring the flag propagates to the internal CLI

## Testing
- `pytest tests/test_pcileech_msix_placeholder_flag.py::TestMsixPlaceholderFlag::test_flag_propagated_to_cli -q --override-ini=addopts=`

------
https://chatgpt.com/codex/tasks/task_b_68b769979670832da861017c5bb76253